### PR TITLE
Fix download to work on windows (by sanitizing filename)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "logic-query-parser": "0.0.5",
     "mustache": "^3.0.1",
     "npm": "^6.4.1",
+    "sanitize-filename": "^1.6.3",
     "sqlite": "^3.0.0",
     "table": "^5.1.0",
     "yamljs": "^0.3.0"

--- a/src/command/SplurtExport.ts
+++ b/src/command/SplurtExport.ts
@@ -65,7 +65,7 @@ export class SplurtExport implements SplurtCommand<void> {
       // create export folder if not exists
       const dir = 'export' //TODO: convert to config option
       if (!fs.existsSync(dir)) fs.mkdirSync(dir)
-      const errorLog = `${dir}/errorLog.txt`
+      const errorLog = `${dir}/error_log.txt`
 
       // create stream for error log
       if (fs.existsSync(errorLog)) fs.unlinkSync(errorLog)

--- a/src/command/SplurtExport.ts
+++ b/src/command/SplurtExport.ts
@@ -99,7 +99,6 @@ export class SplurtExport implements SplurtCommand<void> {
             timeout: 25000 // 25s
           }).then((response) => {
             const filename = sanitize(article.title ? article.title : article.doi)
-            //TODO: make name only have ascii chars
             response.data.pipe(fs.createWriteStream(`${dir}/${filename}.pdf`), { flags: 'w' })
           }).catch((e) => {
             pdfErrorLog.write(`Unable to download:\n${JSON.stringify(article)}\n${e}\n-----\n`)


### PR DESCRIPTION
Additionally, added download errors to an `error_log.txt` file so that the user can pipe the `splurt export` output into a file like html.